### PR TITLE
Enable dynamic refresh for transactions

### DIFF
--- a/src/app/portfolio/components/Transactions/AddTransaction.tsx
+++ b/src/app/portfolio/components/Transactions/AddTransaction.tsx
@@ -24,6 +24,11 @@ import {
 } from "@/components/ui/select";
 import { Plus } from "lucide-react";
 
+interface AddTransactionProps {
+  userId: string | undefined;
+  mutate: () => void;
+}
+
 interface CryptoData {
   name: string;
   amount: number;
@@ -33,7 +38,7 @@ interface CryptoData {
   type: "BUY" | "SELL";
 }
 
-export default function AddTransaction({ userId }: { userId: string | undefined }) {
+export default function AddTransaction({ userId, mutate }: AddTransactionProps) {
   const [open, setOpen] = useState(false);
   const [formData, setFormData] = useState<CryptoData>({
     name: "",
@@ -51,7 +56,7 @@ export default function AddTransaction({ userId }: { userId: string | undefined 
     }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     const dataToSubmit = {
@@ -61,15 +66,12 @@ export default function AddTransaction({ userId }: { userId: string | undefined 
 
     console.log("Submitting crypto data:", dataToSubmit);
 
-    const handleAdd = async () => {
-      try {
-        await localAxios.post(`/api/user/${userId}/transactions`, dataToSubmit);
-        console.log("Transaction added");
-      } catch (error) {
-        console.error("Failed to add transaction:", error);
-      }
-    };
-    handleAdd();
+    try {
+      await localAxios.post(`/api/user/${userId}/transactions`, dataToSubmit);
+      mutate();
+    } catch (error) {
+      console.error("Failed to add transaction:", error);
+    }
 
     setFormData({
       name: "",

--- a/src/app/portfolio/components/Transactions/Columns.tsx
+++ b/src/app/portfolio/components/Transactions/Columns.tsx
@@ -8,7 +8,7 @@ import EditTransaction from "./EditTransaction";
 import { Transaction } from "../../../../types/TransactionSchema";
 import { formatPrice, formatDate } from "@/src/utils/format";
 
-export const Columns: ColumnDef<Transaction>[] = [
+export const getColumns = (mutate: () => void): ColumnDef<Transaction>[] => [
   {
     accessorKey: "name",
     header: "Name",
@@ -62,11 +62,13 @@ export const Columns: ColumnDef<Transaction>[] = [
         <EditTransaction
           userId={row.original.userId}
           transaction={row.original}
-          onUpdated={() => {
-            /* placeholder: refresh data */
-          }}
+          mutate={mutate}
         />
-        <RemoveButton userId={row.original.userId} id={row.original.id} />
+        <RemoveButton
+          userId={row.original.userId}
+          id={row.original.id}
+          mutate={mutate}
+        />
       </div>
     ),
   },

--- a/src/app/portfolio/components/Transactions/EditTransaction.tsx
+++ b/src/app/portfolio/components/Transactions/EditTransaction.tsx
@@ -36,13 +36,13 @@ interface CryptoData {
 interface EditTransactionProps {
   userId?: string;
   transaction: CryptoData;
-  onUpdated?: (updated: CryptoData) => void;
+  mutate: () => void;
 }
 
 export default function EditTransaction({
   userId,
   transaction,
-  onUpdated,
+  mutate,
 }: EditTransactionProps) {
   const [open, setOpen] = useState(false);
   const [formData, setFormData] = useState<Omit<CryptoData, "id">>({
@@ -84,11 +84,11 @@ export default function EditTransaction({
     };
 
     try {
-      const { data: updated } = await localAxios.put<CryptoData>(
+      await localAxios.put<CryptoData>(
         `/api/user/${userId}/transactions/${transaction.id}`,
         payload
       );
-      onUpdated && onUpdated(updated);
+      mutate();
     } catch (error) {
       console.error("Failed to update transaction:", error);
     } finally {

--- a/src/app/portfolio/components/Transactions/RemoveButton.tsx
+++ b/src/app/portfolio/components/Transactions/RemoveButton.tsx
@@ -6,16 +6,16 @@ import { Trash2 } from "lucide-react"; // bin icon
 interface RemoveButtonProps {
   userId: string;
   id: string;
+  mutate: () => void;
 }
 
-const RemoveButton: React.FC<RemoveButtonProps> = ({ userId, id }) => {
+const RemoveButton: React.FC<RemoveButtonProps> = ({ userId, id, mutate }) => {
   const handleRemove = async () => {
     try {
       await localAxios.delete(`/api/user/${userId}/transactions/${id}`);
-      alert("Transaction removed successfully!");
+      mutate();
     } catch (error) {
       console.error("Failed to remove transaction:", error);
-      alert("Failed to remove transaction");
     }
   };
 

--- a/src/app/portfolio/components/Transactions/TransactionTable.tsx
+++ b/src/app/portfolio/components/Transactions/TransactionTable.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import useSWR from "swr";
 import {
-  ColumnDef,
   ColumnFiltersState,
   SortingState,
   flexRender,
@@ -26,21 +26,30 @@ import { FiChevronRight } from "react-icons/fi";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import AddTransaction from "./AddTransaction";
+import { getColumns } from "./Columns";
+import { localAxios } from "@/src/lib/axios";
+import { Transaction } from "@/src/types/TransactionSchema";
 
-interface TransactionTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[];
-  data: TData[];
+interface TransactionTableProps {
   userId: string | undefined;
+  initialData?: Transaction[];
 }
 
-export function TransactionTable<TData, TValue>({
-  columns,
-  data,
-  userId,
-}: TransactionTableProps<TData, TValue>) {
+const fetcher = (url: string) =>
+  localAxios.get(url).then((res) => res.data as Transaction[]);
+
+export function TransactionTable({ userId, initialData }: TransactionTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState({});
+
+  const { data = initialData ?? [], mutate } = useSWR<Transaction[]>(
+    userId ? `/api/user/${userId}/transactions` : null,
+    fetcher,
+    { fallbackData: initialData }
+  );
+
+  const columns = getColumns(mutate);
 
   const table = useReactTable({
     data,
@@ -70,7 +79,7 @@ export function TransactionTable<TData, TValue>({
           }
           className="max-w-sm"
         />
-        <AddTransaction userId={userId} />
+        <AddTransaction userId={userId} mutate={mutate} />
       </div>
       <div className="rounded-md border">
         <Table>

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,4 +1,3 @@
-import { Columns } from "./components/Transactions/Columns";
 import { Transaction } from "../../types/TransactionSchema";
 import { TransactionTable } from "./components/Transactions/TransactionTable";
 import { redirect } from "next/navigation";
@@ -29,7 +28,7 @@ export default async function PortfolioPage() {
   return (
     <div className="container mx-auto">
       <h1 className="text-4xl font-bold text-center mb-5">Transactions</h1>
-      <TransactionTable userId={userId} columns={Columns} data={data} />
+      <TransactionTable userId={userId} initialData={data} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use SWR to fetch transactions client side
- refresh table data after add/edit/delete operations
- rework column helpers to accept refresh callback
- update portfolio page to pass initial data

## Testing
- `npm run lint`
- `npm run build` *(fails: Invalid URL when prerendering)*

------
https://chatgpt.com/codex/tasks/task_e_6883af116de883239b900383b69bec30