### PR TITLE
Fix next-auth module typing

### DIFF
--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,12 +1,11 @@
 import NextAuth, { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
-
   interface Session {
     user: User & DefaultSession["user"];
   }
 
   interface User {
     role: string | null;
-    };
   }
+}


### PR DESCRIPTION
## Summary
- clean up `src/types/next-auth.d.ts` module definition so Session and User are
  properly declared

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884141d1d448323ade1dbd0463b3417