### PR TITLE
Add session checks to user API routes

### DIFF
--- a/src/app/api/user/[userid]/transactions/[id]/route.ts
+++ b/src/app/api/user/[userid]/transactions/[id]/route.ts
@@ -1,9 +1,18 @@
 import prisma from "@/src/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/src/auth";
 
 export async function DELETE(request: NextRequest, { params }: { params: { userid: string, id: string } }) {
     const { userid, id } = params;
     const transactionId = id;
+
+    const session = await auth();
+    if (!session) {
+        return NextResponse.json({ message: 'Not authenticated' }, { status: 401 });
+    }
+    if (session.user.id !== userid) {
+        return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+    }
 
     try {
         const transaction = await prisma.transaction.findFirst({
@@ -30,10 +39,18 @@ export async function DELETE(request: NextRequest, { params }: { params: { useri
     }
 }
   
-  export async function PUT(request: NextRequest, { params }: { params: { userid: string, id: string} }) {
+export async function PUT(request: NextRequest, { params }: { params: { userid: string, id: string} }) {
     const { userid, id } = params;
     const body = await request.json();
     const transactionId = id;
+
+    const session = await auth();
+    if (!session) {
+      return NextResponse.json({ message: 'Not authenticated' }, { status: 401 });
+    }
+    if (session.user.id !== userid) {
+      return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+    }
   
     try {
       const existingTransaction = await prisma.transaction.findFirst({

--- a/src/app/api/user/[userid]/transactions/route.ts
+++ b/src/app/api/user/[userid]/transactions/route.ts
@@ -1,8 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/src/lib/prisma';
+import { auth } from '@/src/auth';
 
 export async function GET(request: NextRequest, { params }: { params: { userid: string } }) {
   const { userid } = params;
+
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ message: 'Not authenticated' }, { status: 401 });
+  }
+  if (session.user.id !== userid) {
+    return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+  }
 
   try {
     const transactions = await prisma.transaction.findMany({
@@ -19,6 +28,14 @@ export async function GET(request: NextRequest, { params }: { params: { userid: 
 export async function POST(request: NextRequest, { params }: { params: { userid: string } }) {
   const { userid } = params;
   const body = await request.json();
+
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ message: 'Not authenticated' }, { status: 401 });
+  }
+  if (session.user.id !== userid) {
+    return NextResponse.json({ message: 'Forbidden' }, { status: 403 });
+  }
 
   try {
     const newTransaction = await prisma.transaction.create({

--- a/src/app/api/user/[userid]/watchlist/[id]/route.ts
+++ b/src/app/api/user/[userid]/watchlist/[id]/route.ts
@@ -1,5 +1,6 @@
 import prisma from "@/src/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/src/auth";
 
 export async function DELETE(
   request: NextRequest,
@@ -7,6 +8,14 @@ export async function DELETE(
 ) {
   const { userid, id } = params;
   const coinId = parseInt(id);
+
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ message: "Not authenticated" }, { status: 401 });
+  }
+  if (session.user.id !== userid) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+  }
 
   try {
     const watchlisted = await prisma.watchlist.findFirst({

--- a/src/app/api/user/[userid]/watchlist/coins/route.ts
+++ b/src/app/api/user/[userid]/watchlist/coins/route.ts
@@ -1,12 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/src/lib/prisma";
 import { cmcAxios } from "@/src/lib/axios";
+import { auth } from "@/src/auth";
 
 export async function GET(
   req: NextRequest,
   { params }: { params: { userid: string } }
 ) {
   const { userid } = params;
+
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ message: "Not authenticated" }, { status: 401 });
+  }
+  if (session.user.id !== userid) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+  }
 
   try {
     const watchlisted = await prisma.watchlist.findMany({

--- a/src/app/api/user/[userid]/watchlist/route.ts
+++ b/src/app/api/user/[userid]/watchlist/route.ts
@@ -1,11 +1,19 @@
 import prisma from "@/src/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/src/auth";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: { userid: string } }
 ) {
   const { userid } = params;
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ message: "Not authenticated" }, { status: 401 });
+  }
+  if (session.user.id !== userid) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+  }
   try {
     const watchlistedCoins = await prisma.watchlist.findMany({
       where: { userId: userid },
@@ -25,6 +33,14 @@ export async function POST(
 ) {
   const { userid } = params;
   const body = await request.json();
+
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ message: "Not authenticated" }, { status: 401 });
+  }
+  if (session.user.id !== userid) {
+    return NextResponse.json({ message: "Forbidden" }, { status: 403 });
+  }
 
   try {
     const newWatchlistedCoin = await prisma.watchlist.create({


### PR DESCRIPTION
## Summary
- verify session ownership in user transaction and watchlist API routes
- block unauthenticated and mismatched users with 401 or 403 responses

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884141d41d8832398276ce0d85e178e